### PR TITLE
Adds configurable artifact persistence

### DIFF
--- a/docs/07-cli-reference.md
+++ b/docs/07-cli-reference.md
@@ -1,0 +1,132 @@
+# CLI Reference
+
+This page documents every CLI command and flag supported by SecureDev‑Bench, with examples for both interactive and non‑interactive usage.
+
+## Overview
+
+- The CLI orchestrates discovering tasks and models, running the agent, building/running Docker, executing tests, and generating reports.
+- Entry points:
+  - Recommended: `python run_benchmark.py`
+  - Advanced: `python -m securedev_bench.cli`
+
+## Interactive Mode
+
+Run without non‑interactive flags:
+
+```bash
+python run_benchmark.py
+```
+
+You will be prompted for:
+
+- Models to test (multi‑select)
+- Tasks to run (multi‑select)
+- Verbose logging toggle
+- Keep temporary directories toggle
+- Save artifacts toggle (and output directory if enabled)
+
+Outputs:
+
+- Console summary table
+- `benchmark_report.md` and `benchmark_report.json` in the project root
+- Optional artifacts (see “Artifacts”)
+
+## Non‑Interactive Mode
+
+Use when automating or scripting runs. You must specify both `--tasks` and `--models`.
+
+```bash
+python run_benchmark.py -y \
+  --tasks task-001-hardcoded-key task-005-insecure-deserialization \
+  --models gemini:gemini-2.5-pro gemini:gemini-2.0-flash-thinking-exp \
+  --verbose \
+  --artifacts-dir artifacts
+```
+
+## Flags and Commands
+
+- **--help, -h**: Show help and exit.
+- **--list**: Print available tasks and models and exit.
+
+- **--tasks <list>**: Space‑separated list of task IDs to run. Required with `-y`.
+  - Example: `--tasks task-001-hardcoded-key task-005-insecure-deserialization`
+
+- **--models <list>**: Space‑separated list of model specs to test. Required with `-y`.
+  - Format: `provider:model_name`
+  - Examples: `gemini:gemini-2.5-pro`, `gemini:gemini-2.0-flash-thinking-exp`
+
+- **--verbose, -v**: Stream detailed logs to stderr (agent output, Docker build/run logs, pytest output).
+
+- **--non-interactive, -y**: Run without prompts. Requires `--tasks` and `--models`.
+
+- **--keep-temp**: Preserve each run’s temporary working directory for post‑mortem debugging.
+  - Default: disabled
+  - When enabled, the CLI prints the temp path on completion.
+
+- **--artifacts-dir <path>**: Directory to save lightweight artifacts (see below).
+  - Default: `artifacts`
+  - Effective only if artifact saving is enabled.
+
+- **--no-artifacts**: Disable saving artifacts.
+  - Default: saving artifacts is enabled in non‑interactive runs
+  - In interactive mode, you control this via a prompt.
+
+## Artifacts
+
+Artifacts are quick‑inspection snapshots saved per run:
+
+- Agent‑modified `app.py` from the temp workspace
+- `report.json` produced by pytest inside the container
+
+Naming: `artifacts/<task>_<timestamp>_<provider>-<model>_app.py` and `_report.json`
+
+Use artifacts to quickly see exactly what the agent changed and how tests evaluated it, without exploring temp directories.
+
+## Reports
+
+- Markdown summary: `benchmark_report.md`
+- JSON summary: `benchmark_report.json`
+
+Each contains per‑model, per‑task results with:
+
+- Result: `SUCCESS`, `TESTS_FAILED`, or `HARNESS_FAILURE`
+- Security and functionality scores: passed/total
+- Duration (seconds)
+
+## Exit Codes
+
+- `0`: CLI completed (reports generated). Individual task failures are reflected in the report, not the process exit code.
+- `1`: CLI usage/environment error (e.g., missing `--tasks`/`--models` in `-y` mode, no models discovered).
+
+### Examples
+
+- Interactive, default settings:
+
+```bash
+python run_benchmark.py
+```
+
+- Non‑interactive, verbose, artifacts saved to a custom dir:
+
+```bash
+python run_benchmark.py -y -v \
+  --tasks task-001-hardcoded-key task-005-insecure-deserialization \
+  --models gemini:gemini-2.5-pro \
+  --artifacts-dir out_artifacts
+```
+
+- Non‑interactive, keep temp directories, disable artifacts:
+
+```bash
+python run_benchmark.py -y \
+  --tasks task-005-insecure-deserialization \
+  --models gemini:gemini-2.0-flash-thinking-exp \
+  --keep-temp --no-artifacts
+```
+
+## Requirements and Notes
+
+- Docker must be installed and running. The CLI builds and runs each task in a container.
+- At least one provider API key must be available via `.env` (e.g., `GEMINI_API_KEY`).
+- Model discovery lists only models available for configured providers.
+- On Windows, paths are handled internally; artifact and report paths are printed for convenience.

--- a/securedev_bench/cli.py
+++ b/securedev_bench/cli.py
@@ -21,7 +21,7 @@ def display_banner():
 
 
 def main():
-    """ --------------- DOCUMENTATION --------------------------------
+    """
     Entry point for the SecureDev-Bench CLI application.
     This function orchestrates the benchmarking process for AI security agents by:
     1. Discovering available tasks and models based on the user's environment and configuration.

--- a/securedev_bench/cli.py
+++ b/securedev_bench/cli.py
@@ -21,7 +21,7 @@ def display_banner():
 
 
 def main():
-    """
+    """ --------------- DOCUMENTATION --------------------------------
     Entry point for the SecureDev-Bench CLI application.
     This function orchestrates the benchmarking process for AI security agents by:
     1. Discovering available tasks and models based on the user's environment and configuration.
@@ -65,6 +65,7 @@ def main():
     run_group.add_argument("-y", "--non-interactive", action="store_true", help="Run in non-interactive mode (requires --tasks and --models).")
     run_group.add_argument("--keep-temp", action="store_true", help="Keep the temporary working directory after each task run for debugging.")
     run_group.add_argument("--artifacts-dir", default="artifacts", help="Directory to store artifacts like modified app.py and report.json (default: artifacts).")
+    run_group.add_argument("--no-artifacts", action="store_true", help="Do not save artifacts (overrides --artifacts-dir).")
     
     args = parser.parse_args()
 
@@ -80,7 +81,7 @@ def main():
         for model in available_models: print(f"  - {model}", file=sys.stderr)
         sys.exit(0)
 
-    # ---Robust Error Handling ---
+    # ---Error Handling ---
     if not available_tasks:
         print(Style.BRIGHT + Fore.RED + "\nError: No task directories found in the 'tasks/' folder.", file=sys.stderr)
         sys.exit(1)
@@ -106,6 +107,12 @@ def main():
         tasks_to_run = questionary.checkbox("Which tasks would you like to run?", choices=available_tasks).ask()
         if not tasks_to_run: sys.exit(0)
         is_verbose = questionary.confirm("Enable verbose (real-time) logging?", default=False).ask()
+        # New interactive toggles
+        keep_temp_choice = questionary.confirm("Keep temporary directories after each run?", default=False).ask()
+        save_artifacts_choice = questionary.confirm("Save artifacts (modified app.py and report.json)?", default=True).ask()
+        artifacts_dir_choice = None
+        if save_artifacts_choice:
+            artifacts_dir_choice = questionary.text("Artifacts output directory:", default="artifacts").ask()
 
     # ---The Main Execution Loop ---
     all_results = []
@@ -120,8 +127,9 @@ def main():
                 provider,
                 model,
                 verbose=is_verbose,
-                keep_temp=args.keep_temp,
-                artifacts_dir=args.artifacts_dir,
+                keep_temp=(args.keep_temp if args.non_interactive else keep_temp_choice),
+                artifacts_dir=(args.artifacts_dir if args.non_interactive else (artifacts_dir_choice or "artifacts")),
+                save_artifacts=(False if args.no_artifacts else (save_artifacts_choice if not args.non_interactive else True)),
             )
             all_results.append(result_data)
     total_duration = time.time() - start_time
@@ -130,5 +138,4 @@ def main():
     # ---Final Reporting ---
     markdown_report_for_console = save_reports(all_results)
     print(Style.BRIGHT + Fore.BLUE + "\n--- Benchmark Summary ---", file=sys.stderr)
-    # The final report to stdout is now colored for the console
     print(markdown_report_for_console)


### PR DESCRIPTION
Introduces a `--no-artifacts` CLI option and interactive prompt to control whether benchmark output files (e.g., modified `app.py`, `report.json`) are saved.

This enhancement provides users with greater control over disk usage and output management, allowing them to disable artifact generation when not needed. Artifacts are saved by default, but this can now be overridden via the command line or interactive prompts.